### PR TITLE
Require and validate mac address at the cli

### DIFF
--- a/eq3bt/eq3cli.py
+++ b/eq3bt/eq3cli.py
@@ -1,6 +1,7 @@
 """ Cli tool for testing connectivity with EQ3 smart thermostats. """
 import logging
 import click
+import re
 from click_datetime import Datetime
 
 from eq3bt import Thermostat
@@ -8,8 +9,13 @@ from eq3bt import Thermostat
 pass_dev = click.make_pass_decorator(Thermostat)
 
 
+def validate_mac(ctx, param, mac):
+    if re.match('^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$', mac) is None:
+        raise click.BadParameter(mac + ' is no valid mac address')
+    return mac
+
 @click.group(invoke_without_command=True)
-@click.option('--mac', envvar="EQ3_MAC")
+@click.option('--mac', envvar="EQ3_MAC", required=True, callback=validate_mac)
 @click.option('--debug/--normal', default=False)
 @click.pass_context
 def cli(ctx, mac, debug):


### PR DESCRIPTION
This uses a click validation function and makes the mac argument required (also works when passed using the environment variable).

This does not add any validation to the library itself, but you can easily catch the [`ValueError`](https://github.com/IanHarvey/bluepy/blob/586c28/bluepy/btle.py#L384-L385) exception yourself, and validating using a regular expression is probably overkill, as the mac usually comes from a config when using the library and was already validated elsewhere.