### PR TITLE
Freeze construct requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 bluepy>=1.0.5
 click
-construct
+construct==2.8.21
 click-datetime


### PR DESCRIPTION
python-eq3bt doesn't work with consturct==2.8.22

Signed-off-by: Tomasz Madycki <themadyc@gmail.com>

It solves:
```Traceback (most recent call last):
  File "bt-window.py", line 2, in <module>
    from eq3bt import Thermostat
  File "/usr/local/lib/python2.7/dist-packages/eq3bt/__init__.py", line 2, in <module>
    from .eq3btsmart import Thermostat, TemperatureException, Mode
  File "/usr/local/lib/python2.7/dist-packages/eq3bt/eq3btsmart.py", line 17, in <module>
    from .structures import *
  File "/usr/local/lib/python2.7/dist-packages/eq3bt/structures.py", line 79, in <module>
    "cmd" / Const(Int8ub, PROP_INFO_RETURN),
  File "/usr/local/lib/python2.7/dist-packages/construct/core.py", line 1277, in __init__
    super(Const, self).__init__(subcon)
  File "/usr/local/lib/python2.7/dist-packages/construct/core.py", line 287, in __init__
    raise TypeError("subcon should be a Construct field")
TypeError: subcon should be a Construct field```