### PR TITLE
fix construct requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 bluepy>=1.0.5
 click
-construct
+construct==2.9.29
 click-datetime


### PR DESCRIPTION
fix construct requirement, newest versions break python-eq3bt again 
this should prevent breaking this module every hassio update again.