### PR TITLE
Context.invoke() -> Context.forward()

### DIFF
--- a/eq3bt/eq3cli.py
+++ b/eq3bt/eq3cli.py
@@ -158,14 +158,14 @@ def state(ctx):
     """ Prints out all available information. """
     dev = ctx.obj
     click.echo(dev)
-    ctx.invoke(locked, ctx)
-    ctx.invoke(low_battery, ctx)
-    ctx.invoke(window_open, ctx)
-    ctx.invoke(boost, ctx)
-    ctx.invoke(temp, ctx)
-    # ctx.invoke(presets, ctx)
-    ctx.invoke(mode, ctx)
-    ctx.invoke(valve_state, ctx)
+    ctx.forward(locked)
+    ctx.forward(low_battery)
+    ctx.forward(window_open)
+    ctx.forward(boost)
+    ctx.forward(temp)
+    # ctx.forward(presets)
+    ctx.forward(mode)
+    ctx.forward(valve_state)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
It seems that for me Context.invoke() also passes the current arguments exactly like forward() and creates errors. So I removed the extra argument and changed all invokes to forwards, which is the more elegant way to begin with.

See: [https://click.palletsprojects.com/en/7.x/advanced/#invoking-other-commands](url)

This fixes issue #26 