### PR TITLE
Decoding presets in status messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ with support for more features and better device handling.
 * Reading device status: locked, low battery, valve state, window open, target temperature, active mode
 * Writing settings: target temperature, auto mode presets, temperature offset
 * Setting the active mode: auto, manual, boost, away
+* Reading presets and temperature offset in more recent firmware versions.
 
 ## Not (yet) supported)
 
-* Reading presets, temperature offset. This may not be possible.
 * No easy-to-use interface for setting schedules.
 
 # Installation
@@ -70,8 +70,12 @@ eq3cli
 Locked: False
 Batter low: False
 Window open: False
+Window open temp: 12.0
+Window open time: 0:15:00
 Boost: False
 Current target temp: 17.0
+Current comfort temp: 20.0
+Current eco temp: 17.0
 Current mode: auto dst locked
 Valve: 0
 ```

--- a/eq3bt/eq3btsmart.py
+++ b/eq3bt/eq3btsmart.py
@@ -165,7 +165,8 @@ class Thermostat:
             _LOGGER.debug("Mode:             %s", self.mode_readable)
             _LOGGER.debug("Target temp:      %s", self._target_temperature)
             _LOGGER.debug("Away end:         %s", self._away_end)
-            _LOGGER.debug("Window open temp: %s", self._window_open_temperature)
+            _LOGGER.debug("Window open temp: %s",
+                          self._window_open_temperature)
             _LOGGER.debug("Window open time: %s", self._window_open_time)
             _LOGGER.debug("Comfort temp:     %s", self._comfort_temperature)
             _LOGGER.debug("Eco temp:         %s", self._eco_temperature)

--- a/eq3bt/eq3btsmart.py
+++ b/eq3bt/eq3btsmart.py
@@ -161,10 +161,15 @@ class Thermostat:
                 self._eco_temperature = None
                 self._temperature_offset = None
 
-            _LOGGER.debug("Valve state: %s", self._valve_state)
-            _LOGGER.debug("Mode:        %s", self.mode_readable)
-            _LOGGER.debug("Target temp: %s", self._target_temperature)
-            _LOGGER.debug("Away end:    %s", self._away_end)
+            _LOGGER.debug("Valve state:      %s", self._valve_state)
+            _LOGGER.debug("Mode:             %s", self.mode_readable)
+            _LOGGER.debug("Target temp:      %s", self._target_temperature)
+            _LOGGER.debug("Away end:         %s", self._away_end)
+            _LOGGER.debug("Window open temp: %s", self._window_open_temperature)
+            _LOGGER.debug("Window open time: %s", self._window_open_time)
+            _LOGGER.debug("Comfort temp:     %s", self._comfort_temperature)
+            _LOGGER.debug("Eco temp:         %s", self._eco_temperature)
+            _LOGGER.debug("Temp offset:      %s", self._temperature_offset)
 
         elif data[0] == PROP_SCHEDULE_RETURN:
             parsed = self.parse_schedule(data)

--- a/eq3bt/eq3btsmart.py
+++ b/eq3bt/eq3btsmart.py
@@ -11,6 +11,7 @@ import logging
 import struct
 import codecs
 from datetime import datetime, timedelta, time
+from construct import Byte
 from enum import IntEnum
 
 from .connection import BTLEConnection

--- a/eq3bt/eq3btsmart.py
+++ b/eq3bt/eq3btsmart.py
@@ -80,11 +80,11 @@ class Thermostat:
 
         self._schedule = {}
 
-        self._window_open_temperature = Mode.Unknown
-        self._window_open_time = Mode.Unknown
-        self._comfort_temperature = Mode.Unknown
-        self._eco_temperature = Mode.Unknown
-        self._temperature_offset = Mode.Unknown
+        self._window_open_temperature = None
+        self._window_open_time = None
+        self._comfort_temperature = None
+        self._eco_temperature = None
+        self._temperature_offset = None
 
         self._away_temp = EQ3BT_AWAY_TEMP
         self._away_duration = timedelta(days=30)
@@ -153,6 +153,12 @@ class Thermostat:
                 self._comfort_temperature = presets.comfort_temp
                 self._eco_temperature = presets.eco_temp
                 self._temperature_offset = presets.offset
+            else:
+                self._window_open_temperature = None
+                self._window_open_time = None
+                self._comfort_temperature = None
+                self._eco_temperature = None
+                self._temperature_offset = None
 
             _LOGGER.debug("Valve state: %s", self._valve_state)
             _LOGGER.debug("Mode:        %s", self.mode_readable)
@@ -344,7 +350,7 @@ class Thermostat:
 
     @window_open_temperature.setter
     def window_open_temperature(self, value):
-        if self._window_open_time == Mode.Unknown:
+        if self._window_open_time is None:
             raise ValueError("Presets cannot be read. Please try updating the device firmware.")
         self.window_open_config(value, self._window_open_time)
 
@@ -355,7 +361,7 @@ class Thermostat:
 
     @window_open_time.setter
     def window_open_time(self, value):
-        if self._window_open_temperature == Mode.Unknown:
+        if self._window_open_temperature is None:
             raise ValueError("Presets cannot be read. Please try updating the device firmware.")
         if not isinstance(value, timedelta):
             value = timedelta(minutes=value)
@@ -395,7 +401,7 @@ class Thermostat:
 
     @comfort_temperature.setter
     def comfort_temperature(self, value):
-        if self._eco_temperature == Mode.Unknown:
+        if self._eco_temperature is None:
             raise ValueError("Presets cannot be read. Please try updating the device firmware.")
         self.temperature_presets(value, self._eco_temperature)
 
@@ -406,7 +412,7 @@ class Thermostat:
 
     @eco_temperature.setter
     def eco_temperature(self, value):
-        if self._comfort_temperature == Mode.Unknown:
+        if self._comfort_temperature is None:
             raise ValueError("Presets cannot be read. Please try updating the device firmware.")
         self.temperature_presets(self._comfort_temperature, value)
 

--- a/eq3bt/eq3btsmart.py
+++ b/eq3bt/eq3btsmart.py
@@ -348,24 +348,10 @@ class Thermostat:
         """The temperature to set when an open window is detected."""
         return self._window_open_temperature
 
-    @window_open_temperature.setter
-    def window_open_temperature(self, value):
-        if self._window_open_time is None:
-            raise ValueError("Presets cannot be read. Please try updating the device firmware.")
-        self.window_open_config(value, self._window_open_time)
-
     @property
     def window_open_time(self):
         """Timeout to reset the thermostat after an open window is detected."""
         return self._window_open_time
-
-    @window_open_time.setter
-    def window_open_time(self, value):
-        if self._window_open_temperature is None:
-            raise ValueError("Presets cannot be read. Please try updating the device firmware.")
-        if not isinstance(value, timedelta):
-            value = timedelta(minutes=value)
-        self.window_open_config(self.window_open_temperature, value)
 
     @property
     def locked(self):
@@ -396,25 +382,13 @@ class Thermostat:
 
     @property
     def comfort_temperature(self):
-        """The comfort temperature preset of the thermostat."""
+        """Returns the comfort temperature preset of the thermostat."""
         return self._comfort_temperature
-
-    @comfort_temperature.setter
-    def comfort_temperature(self, value):
-        if self._eco_temperature is None:
-            raise ValueError("Presets cannot be read. Please try updating the device firmware.")
-        self.temperature_presets(value, self._eco_temperature)
 
     @property
     def eco_temperature(self):
-        """The eco temperature preset of the thermostat."""
+        """Returns the eco temperature preset of the thermostat."""
         return self._eco_temperature
-
-    @eco_temperature.setter
-    def eco_temperature(self, value):
-        if self._comfort_temperature is None:
-            raise ValueError("Presets cannot be read. Please try updating the device firmware.")
-        self.temperature_presets(self._comfort_temperature, value)
 
     @property
     def temperature_offset(self):

--- a/eq3bt/eq3cli.py
+++ b/eq3bt/eq3cli.py
@@ -113,8 +113,8 @@ def window_open(dev, temp, duration):
 
 
 @cli.command()
-@click.option('--comfort', type=float)
-@click.option('--eco', type=float)
+@click.option('--comfort', type=float, required=False)
+@click.option('--eco', type=float, required=False)
 @pass_dev
 def presets(dev, comfort, eco):
     """ Sets the preset temperatures for auto mode. """
@@ -142,13 +142,18 @@ def schedule(dev):
             click.echo("\t[%s-%s] %s" % (current_hour, hour.next_change_at, hour.target_temp))
             current_hour = hour.next_change_at
 
+
 @cli.command()
-@click.argument('offset', type=float)
+@click.argument('offset', type=float, required=False)
 @pass_dev
 def offset(dev, offset):
     """ Sets the temperature offset [-3,5 3,5] """
-    click.echo("Setting the offset to %s" % offset)
-    dev.temperature_offset = offset
+    if dev.temperature_offset is not None:
+        click.echo("Current temp offset: %s" % dev.temperature_offset)
+    if offset is not None:
+        click.echo("Setting the offset to %s" % offset)
+        dev.temperature_offset = offset
+
 
 @cli.command()
 @click.argument('away_end', type=Datetime(format='%Y-%m-%d %H:%M'), default=None, required=False)
@@ -174,6 +179,7 @@ def state(ctx):
     ctx.forward(boost)
     ctx.forward(temp)
     ctx.forward(presets)
+    ctx.forward(offset)
     ctx.forward(mode)
     ctx.forward(valve_state)
 

--- a/eq3bt/eq3cli.py
+++ b/eq3bt/eq3cli.py
@@ -103,6 +103,10 @@ def low_battery(dev):
 def window_open(dev, temp, duration):
     """ Gets and sets the window open settings. """
     click.echo("Window open: %s" % dev.window_open)
+    if dev.window_open_temperature is not None:
+        click.echo("Window open temp: %s" % dev.window_open_temperature)
+    if dev.window_open_time is not None:
+        click.echo("Window open time: %s" % dev.window_open_time)
     if temp and duration:
         click.echo("Setting window open conf, temp: %s duration: %s" % (temp, duration))
         dev.window_open_config(temp, duration)
@@ -114,8 +118,14 @@ def window_open(dev, temp, duration):
 @pass_dev
 def presets(dev, comfort, eco):
     """ Sets the preset temperatures for auto mode. """
-    click.echo("Setting presets: comfort %s, eco %s" % (comfort, eco))
-    dev.temperature_presets(comfort, eco)
+    if dev.comfort_temperature is not None:
+        click.echo("Current comfort temp: %s" % dev.comfort_temperature)
+    if dev.eco_temperature is not None:
+        click.echo("Current eco temp: %s" % dev.eco_temperature)
+    if comfort and eco:
+        click.echo("Setting presets: comfort %s, eco %s" % (comfort, eco))
+        dev.temperature_presets(comfort, eco)
+
 
 @cli.command()
 @pass_dev
@@ -138,7 +148,7 @@ def schedule(dev):
 def offset(dev, offset):
     """ Sets the temperature offset [-3,5 3,5] """
     click.echo("Setting the offset to %s" % offset)
-    dev.temperature_offset(offset)
+    dev.temperature_offset = offset
 
 @cli.command()
 @click.argument('away_end', type=Datetime(format='%Y-%m-%d %H:%M'), default=None, required=False)
@@ -163,7 +173,7 @@ def state(ctx):
     ctx.forward(window_open)
     ctx.forward(boost)
     ctx.forward(temp)
-    # ctx.forward(presets)
+    ctx.forward(presets)
     ctx.forward(mode)
     ctx.forward(valve_state)
 

--- a/eq3bt/structures.py
+++ b/eq3bt/structures.py
@@ -46,7 +46,8 @@ class WindowOpenTimeAdapter(Adapter):
             obj = obj.seconds
         if 0 <= obj <= 3600.0:
             return int(obj / 300.0)
-        raise ValueError("Window open time must be between 0 and 60 minutes in intervals of 5 minutes.")
+        raise ValueError("Window open time must be between 0 and 60 minutes "
+                         "in intervals of 5 minutes.")
 
 
 class TempOffsetAdapter(Adapter):
@@ -57,7 +58,8 @@ class TempOffsetAdapter(Adapter):
     def _encode(self, obj, context, path):
         if -3.5 <= obj <= 3.5:
             return int(obj * 2.0) + 7
-        raise ValueError("Temperature offset must be between -3.5 and 3.5 (in intervals of 0.5).")
+        raise ValueError("Temperature offset must be between -3.5 and 3.5 (in "
+                         "intervals of 0.5).")
 
 
 ModeFlags = "ModeFlags" / FlagsEnum(Int8ub,

--- a/eq3bt/tests/test_thermostat.py
+++ b/eq3bt/tests/test_thermostat.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 import codecs
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from eq3bt import Thermostat, TemperatureException
 from eq3bt.eq3btsmart import (PROP_NTFY_HANDLE, PROP_ID_QUERY,
@@ -17,6 +17,7 @@ STATUS_RESPONSES = {
     'boost': b'020104000428',
     'low_batt': b'020180000428',
     'valve_at_22': b'020100160428',
+    'presets': b'020100000422000000001803282207',
 }
 
 
@@ -94,6 +95,16 @@ class TestThermostat(TestCase):
         th.update()
         self.assertTrue(th.boost)
         self.assertEqual(th.mode, Mode.Boost)
+
+    def test_presets(self):
+        th = self.thermostat
+        self.thermostat._conn.set_status('presets')
+        self.thermostat.update()
+        self.assertEqual(th.window_open_temperature, 12.0)
+        self.assertEqual(th.window_open_time, timedelta(minutes=15.0))
+        self.assertEqual(th.comfort_temperature, 20.0)
+        self.assertEqual(th.eco_temperature, 17.0)
+        self.assertEqual(th.temperature_offset, 0)
 
     def test_query_schedule(self):
         self.fail()

--- a/eq3bt/tests/test_thermostat.py
+++ b/eq3bt/tests/test_thermostat.py
@@ -1,12 +1,51 @@
 from unittest import TestCase
+
+import codecs
+from datetime import datetime
+
 from eq3bt import Thermostat, TemperatureException
+from eq3bt.eq3btsmart import (PROP_NTFY_HANDLE, PROP_ID_QUERY,
+                              PROP_INFO_QUERY, Mode)
+
+
+ID_RESPONSE = b'01780000807581626163606067659e'
+STATUS_RESPONSES = {
+    'auto': b'020100000428',
+    'manual': b'020101000428',
+    'window': b'020110000428',
+    'away': b'0201020004231d132e03',
+    'boost': b'020104000428',
+    'low_batt': b'020180000428',
+    'valve_at_22': b'020100160428',
+}
+
 
 class FakeConnection:
     def __init__(self, mac):
-        pass
+        self._callbacks = {}
+        self._res = 'auto'
 
     def set_callback(self, handle, cb):
-        pass
+        self._callbacks[handle] = cb
+
+    def set_status(self, key):
+        if key in STATUS_RESPONSES:
+            self._res = key
+        else:
+            raise ValueError("Invalid key for status test response.")
+
+    def make_request(self, handle, value, timeout=1, with_response=True):
+        """Write a GATT Command without callback - not utf-8."""
+        if with_response:
+            cb = self._callbacks.get(PROP_NTFY_HANDLE)
+
+            if value[0] == PROP_ID_QUERY:
+                data = ID_RESPONSE
+            elif value[0] == PROP_INFO_QUERY:
+                data = STATUS_RESPONSES[self._res]
+            else:
+                return
+            cb(codecs.decode(data, 'hex'))
 
 
 class TestThermostat(TestCase):
@@ -29,7 +68,32 @@ class TestThermostat(TestCase):
         self.fail()
 
     def test_update(self):
-        self.fail()
+        th = self.thermostat
+
+        th._conn.set_status('auto')
+        th.update()
+        self.assertEqual(th.valve_state, 0)
+        self.assertEqual(th.mode, Mode.Auto)
+        self.assertEqual(th.target_temperature, 20.0)
+        self.assertFalse(th.locked)
+        self.assertFalse(th.low_battery)
+        self.assertFalse(th.boost)
+        self.assertFalse(th.window_open)
+
+        th._conn.set_status('manual')
+        th.update()
+        self.assertTrue(th.mode, Mode.Manual)
+
+        th._conn.set_status('away')
+        th.update()
+        self.assertEqual(th.mode, Mode.Away)
+        self.assertEqual(th.target_temperature, 17.5)
+        self.assertEqual(th.away_end, datetime(2019, 3, 29, 23, 00))
+
+        th._conn.set_status('boost')
+        th.update()
+        self.assertTrue(th.boost)
+        self.assertEqual(th.mode, Mode.Boost)
 
     def test_query_schedule(self):
         self.fail()
@@ -53,10 +117,16 @@ class TestThermostat(TestCase):
         self.fail()
 
     def test_valve_state(self):
-        self.fail()
+        th = self.thermostat
+        th._conn.set_status('valve_at_22')
+        th.update()
+        self.assertEqual(th.valve_state, 22)
 
     def test_window_open(self):
-        self.fail()
+        th = self.thermostat
+        th._conn.set_status('window')
+        th.update()
+        self.assertTrue(th.window_open)
 
     def test_window_open_config(self):
         self.fail()
@@ -65,7 +135,10 @@ class TestThermostat(TestCase):
         self.fail()
 
     def test_low_battery(self):
-        self.fail()
+        th = self.thermostat
+        th._conn.set_status('low_batt')
+        th.update()
+        self.assertTrue(th.low_battery)
 
     def test_temperature_offset(self):
         self.fail()


### PR DESCRIPTION
Using the debug output of the CLI tool, I discovered that my thermostats' status messages invariably returned extra bytes after the "away" (vacation) mode and end time (padded with zeroes where not applicable). This additional information contains the temperature presets (eco, comfort), window-open-settings, and the current temperature offset.

I assume that whether they are present or not depends on the firmware version. I changed the structures accordingly to tolerate both the new and the old format of the output. Some tests are added to ensure this does not break previous behavior.