### PR TITLE
use all hci ifaces, support keep_connection, support multiple callbacks

### DIFF
--- a/eq3bt/connection.py
+++ b/eq3bt/connection.py
@@ -4,6 +4,8 @@ Handles Connection duties (reconnecting etc.) transparently.
 """
 import logging
 import codecs
+import dbus
+import re
 
 from bluepy import btle
 
@@ -15,13 +17,36 @@ _LOGGER = logging.getLogger(__name__)
 class BTLEConnection(btle.DefaultDelegate):
     """Representation of a BTLE Connection."""
 
-    def __init__(self, mac):
+    def __init__(self, mac, keep_connected=False):
         """Initialize the connection."""
         btle.DefaultDelegate.__init__(self)
+
+        self._ifaces = self.get_hci_ifaces()
+        self._iface_idx = 0
 
         self._conn = None
         self._mac = mac
         self._callbacks = {}
+        self._keep_connected = keep_connected
+    
+    def next_iface(self):
+        self._nr_conn_errors += 1
+        self._iface_idx = (self._iface_idx + 1) % len(self._ifaces)
+        if self._nr_conn_errors >= len(self._ifaces)*2:
+            return False
+        return True
+
+    def get_hci_ifaces(self):
+        iface_list = []
+        bus = dbus.SystemBus()
+        manager = dbus.Interface(bus.get_object("org.bluez", "/"), "org.freedesktop.DBus.ObjectManager")
+        objects = manager.GetManagedObjects()
+        for path, interfaces in objects.items():
+            adapter = interfaces.get("org.bluez.Adapter1")
+            if adapter is None:
+                continue
+            iface_list.append(re.search(r'\d+$', path)[0])
+        return iface_list
 
     def __enter__(self):
         """
@@ -29,24 +54,37 @@ class BTLEConnection(btle.DefaultDelegate):
         :rtype: btle.Peripheral
         :return:
         """
-        self._conn = btle.Peripheral()
-        self._conn.withDelegate(self)
-        _LOGGER.debug("Trying to connect to %s", self._mac)
         try:
-            self._conn.connect(self._mac)
-        except btle.BTLEException as ex:
-            _LOGGER.debug("Unable to connect to the device %s, retrying: %s", self._mac, ex)
-            try:
-                self._conn.connect(self._mac)
-            except Exception as ex2:
-                _LOGGER.debug("Second connection try to %s failed: %s", self._mac, ex2)
-                raise
+            conn_state = self._conn.getState()
+        except:
+            self._conn = None
+
+        if self._conn is None or conn_state != "conn":
+            self._conn = btle.Peripheral()
+            self._conn.withDelegate(self)
+            self._nr_conn_errors = 0
+            _LOGGER.debug("Trying to connect to %s", self._mac)
+            while True:
+                # try to connect with all ifaces
+                try:
+                    self._conn.connect(self._mac, iface=self._ifaces[self._iface_idx])
+                    break
+                except btle.BTLEException as ex:
+                    _LOGGER.debug("Unable to connect to the device %s using iface %s, retrying: %s", self._mac, self._ifaces[self._iface_idx], ex)
+                    try:
+                        self._conn.connect(self._mac, iface=self._ifaces[self._iface_idx])
+                        break
+                    except Exception as ex2:
+                        _LOGGER.debug("Second connection try to %s using ifaces %s failed: %s", self._mac, self._ifaces[self._iface_idx], ex2)
+                        if self.next_iface() is False:
+                            # tried all ifaces, raise exception
+                            raise
 
         _LOGGER.debug("Connected to %s", self._mac)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self._conn:
+        if self._conn and self._keep_connected is False:
             self._conn.disconnect()
             self._conn = None
 
@@ -54,7 +92,8 @@ class BTLEConnection(btle.DefaultDelegate):
         """Handle Callback from a Bluetooth (GATT) request."""
         _LOGGER.debug("Got notification from %s: %s", handle, codecs.encode(data, 'hex'))
         if handle in self._callbacks:
-            self._callbacks[handle](data)
+            for callback in self._callbacks[handle]:
+                callback(data)
 
     @property
     def mac(self):
@@ -63,7 +102,9 @@ class BTLEConnection(btle.DefaultDelegate):
 
     def set_callback(self, handle, function):
         """Set the callback for a Notification handle. It will be called with the parameter data, which is binary."""
-        self._callbacks[handle] = function
+        if handle not in self._callbacks:
+            self._callbacks[handle] = []
+        self._callbacks[handle].append(function)
 
     def make_request(self, handle, value, timeout=DEFAULT_TIMEOUT, with_response=True):
         """Write a GATT Command without callback - not utf-8."""

--- a/eq3bt/eq3btsmart.py
+++ b/eq3bt/eq3btsmart.py
@@ -71,7 +71,7 @@ class TemperatureException(Exception):
 class Thermostat:
     """Representation of a EQ3 Bluetooth Smart thermostat."""
 
-    def __init__(self, _mac, connection_cls=BTLEConnection):
+    def __init__(self, _mac, connection_cls=BTLEConnection, keep_connection=False):
         """Initialize the thermostat."""
 
         self._target_temperature = Mode.Unknown
@@ -94,7 +94,7 @@ class Thermostat:
         self._firmware_version = None
         self._device_serial = None
 
-        self._conn = connection_cls(_mac)
+        self._conn = connection_cls(_mac, keep_connection)
         self._conn.set_callback(PROP_NTFY_HANDLE, self.handle_notification)
 
     def __str__(self):


### PR DESCRIPTION
support multiple hci interfaces:
Tries to connect via all available interfaces and sticks to one if the connection works.

support keep connection alive:
Allows the user to keep the connection alive and re-establishes the connection if it dropped inbetween.

support multiple callbacks:
Allow to register multiple callbacks.