### PR TITLE
Add mac property to thermostat class

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.1.0
+  rev: v4.3.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
@@ -10,13 +10,13 @@ repos:
   - id: check-ast
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.31.0
+  rev: v2.35.0
   hooks:
   - id: pyupgrade
     args: ['--py37-plus']
 
 - repo: https://github.com/python/black
-  rev: 22.1.0
+  rev: 22.6.0
   hooks:
   - id: black
 
@@ -32,6 +32,6 @@ repos:
     additional_dependencies: [toml]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.931
+  rev: v0.961
   hooks:
   - id: mypy

--- a/eq3bt/eq3btsmart.py
+++ b/eq3bt/eq3btsmart.py
@@ -484,3 +484,8 @@ class Thermostat:
     def device_serial(self):
         """Return the device serial number."""
         return self._device_serial
+
+    @property
+    def mac(self):
+        """Return the mac address."""
+        return self._conn.mac


### PR DESCRIPTION
Exposes the mac address for downstream without having to touch the connection class internals.