### PR TITLE
Wrap backend exceptions inside BackendException

### DIFF
--- a/eq3bt/__init__.py
+++ b/eq3bt/__init__.py
@@ -1,3 +1,7 @@
 # flake8: noqa
 from .eq3btsmart import Mode, TemperatureException, Thermostat
 from .structures import *
+
+
+class BackendException(Exception):
+    """Exception to wrap backend exceptions."""

--- a/eq3bt/connection.py
+++ b/eq3bt/connection.py
@@ -7,6 +7,8 @@ import logging
 
 from bluepy import btle
 
+from . import BackendException
+
 DEFAULT_TIMEOUT = 1
 
 _LOGGER = logging.getLogger(__name__)
@@ -43,7 +45,9 @@ class BTLEConnection(btle.DefaultDelegate):
                 self._conn.connect(self._mac, iface=self._iface)
             except Exception as ex2:
                 _LOGGER.debug("Second connection try to %s failed: %s", self._mac, ex2)
-                raise
+                raise BackendException(
+                    "Unable to connect to device using bluepy"
+                ) from ex2
 
         _LOGGER.debug("Connected to %s", self._mac)
         return self
@@ -88,4 +92,4 @@ class BTLEConnection(btle.DefaultDelegate):
                     self._conn.waitForNotifications(timeout)
         except btle.BTLEException as ex:
             _LOGGER.debug("Got exception from bluepy while making a request: %s", ex)
-            raise
+            raise BackendException("Exception on write using bluepy") from ex

--- a/eq3bt/gattlibconnection.py
+++ b/eq3bt/gattlibconnection.py
@@ -8,6 +8,8 @@ import threading
 
 import gattlib
 
+from . import BackendException
+
 DEFAULT_TIMEOUT = 1
 
 _LOGGER = logging.getLogger(__name__)
@@ -47,7 +49,9 @@ class BTLEConnection:
                 self._conn.connect()
             except Exception as ex2:
                 _LOGGER.debug("Second connection try to %s failed: %s", self._mac, ex2)
-                raise
+                raise BackendException(
+                    "unable to connect to device using gattlib"
+                ) from ex2
 
         _LOGGER.debug("Connected to %s", self._mac)
         return self
@@ -92,4 +96,4 @@ class BTLEConnection:
                     self._notifyevent.wait(timeout)
         except gattlib.BTBaseException as ex:
             _LOGGER.debug("Got exception from gattlib while making a request: %s", ex)
-            raise
+            raise BackendException("Exception on write using gattlib") from ex


### PR DESCRIPTION
This allows downstreams to except on a single exception without requiring catching backend specific exceptions.

Related to #50