### PR TITLE
Release 0.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,24 @@
 Changelog
 =========
 
+0.2 (2022-07-13)
+----------------
+
+- Add publish to pypi workflow (#54) [Teemu R]
+
+- Add bleak backend and make it default (#53) [Teemu R]
+
+- Wrap backend exceptions inside BackendException (#52) [Teemu R]
+
+- Add mac property to thermostat class (#51) [Teemu R]
+
+- Update README, pyproject.toml (#49) [Teemu R]
+
+- Support gattlib as an alternative btle library (#48) [Helmut Grohne]
+
+- Use poetry, add pre-commit hooks & mass format to modern standards,
+  add CI (#47) [Teemu R]
+
 
 0.1.12 (2021-11-13)
 -------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "python-eq3bt"
-version = "0.1.12"
+version = "0.2"
 description = "EQ3 bluetooth thermostat support library"
 license = "MIT"
 authors = ["Teemu R. <tpr@iki.fi>", "Markus Peter <mpeter@emdev.de>"]


### PR DESCRIPTION
This release adds two new backends: bleak and gattlib.
Bleak backend is the new default backend which makes this library
work also on non-Linux platforms and requires no compiler to be installed.

0.2 (2022-07-13)
----------------

- Add publish to pypi workflow (#54) [Teemu R]

- Add bleak backend and make it default (#53) [Teemu R]

- Wrap backend exceptions inside BackendException (#52) [Teemu R]

- Add mac property to thermostat class (#51) [Teemu R]

- Update README, pyproject.toml (#49) [Teemu R]

- Support gattlib as an alternative btle library (#48) [Helmut Grohne]

- Use poetry, add pre-commit hooks & mass format to modern standards,
  add CI (#47) [Teemu R]
