### PR TITLE
Create event loop only when necessary

### DIFF
--- a/eq3bt/bleakconnection.py
+++ b/eq3bt/bleakconnection.py
@@ -33,7 +33,12 @@ class BleakConnection:
         self._callbacks = {}
         self._notifyevent = asyncio.Event()
         self._notification_handle = None
-        self._loop = asyncio.new_event_loop()
+
+        try:
+            self._loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self._loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self._loop)
 
     def __enter__(self):
         """


### PR DESCRIPTION
Calling `new_event_loop()` created a second event loop on python <3.10, and `asyncio.wait_for()` created a task on the wrong loop, apparently.

This PR checks if a loop exists already, and creates one only if none is available. Tested to work both using the dockerfile in the linked issue, and when it gets used by homeassistant.

Fixes #57