### PR TITLE
Fix parameter type in notification callback and initialize Event after event loop initialization

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
   hooks:
   - id: black
 
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: 3.9.2
   hooks:
   - id: flake8

--- a/eq3bt/bleakconnection.py
+++ b/eq3bt/bleakconnection.py
@@ -43,7 +43,6 @@ class BleakConnection:
 
         self._notifyevent = asyncio.Event()
 
-
     def __enter__(self):
         """
         Context manager __enter__ for connecting the device
@@ -86,7 +85,11 @@ class BleakConnection:
     async def on_notification(self, characteristic, data):
         """Handle Callback from a Bluetooth (GATT) request."""
         # The notification handles are off-by-one compared to gattlib and bluepy
-        handle = characteristic.handle + 1
+        try:
+            handle = characteristic.handle + 1
+        except:  # noqa: E722 # fallback to old-style, int-based handle
+            handle = characteristic + 1
+
         _LOGGER.debug(
             "Got notification from %s: %s", handle, codecs.encode(data, "hex")
         )

--- a/eq3bt/bleakconnection.py
+++ b/eq3bt/bleakconnection.py
@@ -31,14 +31,18 @@ class BleakConnection:
         self._mac = mac
         self._iface = iface
         self._callbacks = {}
-        self._notifyevent = asyncio.Event()
         self._notification_handle = None
 
         try:
             self._loop = asyncio.get_running_loop()
+            _LOGGER.debug("Using existing asyncio loop")
         except RuntimeError:
             self._loop = asyncio.new_event_loop()
+            _LOGGER.debug("Creating new asyncio loop")
             asyncio.set_event_loop(self._loop)
+
+        self._notifyevent = asyncio.Event()
+
 
     def __enter__(self):
         """
@@ -79,10 +83,10 @@ class BleakConnection:
             self._loop.run_until_complete(self._conn.disconnect())
             self._conn = None
 
-    async def on_notification(self, handle, data):
+    async def on_notification(self, characteristic, data):
         """Handle Callback from a Bluetooth (GATT) request."""
         # The notification handles are off-by-one compared to gattlib and bluepy
-        handle = handle + 1
+        handle = characteristic.handle + 1
         _LOGGER.debug(
             "Got notification from %s: %s", handle, codecs.encode(data, "hex")
         )


### PR DESCRIPTION
## Description

Bleak introduced a breaking change a few days ago changing the notification callback first parameter's type to `BleakGATTCharacteristic` (was `int` before). This lead to the following exception during runtime:

```
Traceback (most recent call last):
  File "/XXXXX/XXXXX/.local/lib/python3.9/site-packages/eq3bt/bleakconnection.py", line 80, in on_notification
    handle = handle + 1
TypeError: unsupported operand type(s) for +: 'BleakGATTCharacteristicBlueZDBus' and 'int'
```
This is now fixed by using `BleakGATTCharacteristic`'s `handle` property instead.

Also, this PR moves the initialization of the asyncio `Event` object after the initialization of the event loop, because it seems that `asyncio.Event()` creates a loop if none is present. The debug logs print out

```
DEBUG:asyncio:Using selector: EpollSelector
DEBUG:asyncio:Using selector: EpollSelector
...
Traceback (most recent call last):
  File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/XXXXX/XXXXX/XXXXX/python-eq3bt/eq3bt/eq3cli.py", line 212, in <module>
    cli()
  File "/XXXXX/XXXXX/XXXXX/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/XXXXX/XXXXX/XXXXX/lib/python3.9/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/XXXXX/XXXXX/XXXXX/lib/python3.9/site-packages/click/core.py", line 1635, in invoke
    rv = super().invoke(ctx)
  File "/XXXXX/XXXXX/XXXXX/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/XXXXX/XXXXX/XXXXX/lib/python3.9/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/XXXXX/XXXXX/XXXXX/lib/python3.9/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/XXXXX/XXXXX/XXXXX/python-eq3bt/eq3bt/eq3cli.py", line 47, in cli
    thermostat.update()
  File "/XXXXX/XXXXX/XXXXX/python-eq3bt/eq3bt/eq3btsmart.py", line 217, in update
    self._conn.make_request(PROP_WRITE_HANDLE, value)
  File "/XXXXX/XXXXX/XXXXX/python-eq3bt/eq3bt/bleakconnection.py", line 127, in make_request
    self._loop.run_until_complete(self.wait_for_response(timeout))
  File "/usr/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/XXXXX/XXXXX/XXXXX/python-eq3bt/eq3bt/bleakconnection.py", line 109, in wait_for_response
    await asyncio.wait_for(self._notifyevent.wait(), timeout)
  File "/usr/lib/python3.9/asyncio/tasks.py", line 481, in wait_for
    return fut.result()
  File "/usr/lib/python3.9/asyncio/locks.py", line 226, in wait
    await fut
RuntimeError: Task <Task pending name='Task-7' coro=<Event.wait() running at /usr/lib/python3.9/asyncio/locks.py:226> cb=[_release_waiter(<Future pendi...0a79089d0>()]>)() at /usr/lib/python3.9/asyncio/tasks.py:416]> got Future <Future pending> attached to a different loop
```

when the `Event` object gets initialized before the loop. Putting it after the loop initialization `asyncio` prints the mentioned debug log only once and the exception is gone.

## Related Issues

Fixes #63 
Fixes #56