### PR TITLE
Fix flake8 precommit url

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
   hooks:
   - id: black
 
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: 3.9.2
   hooks:
   - id: flake8


### PR DESCRIPTION
Flake8 gitlab repo does not exists for a while, this PR fixes the build.